### PR TITLE
fixing URL for doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # JuLS : A Julia Local Search solver
 
-[![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://amazon-science.github.io/JuLS.jl/dev/)
+[![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://amazon-science.github.io/JuLS/dev/)
 
 </div>
 


### PR DESCRIPTION
quick fox to the doc URL in README